### PR TITLE
Aligned sidebar contents

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,22 +1,32 @@
 * [Home](/)
+
 * [Getting Started](getting_started.md)
+
 * [Video Demos](video_demos.md)
-* [Saving Projects](saving_project.md)
+
+* [Saving Project](saving_project.md)
+
 * [Modifying Circuit Elements](Modify.md)
-* [SubCircuits](subcircuit.md)
+
+* [Subcircuits](subcircuit.md)
+
 * [Exporting Images](export.md)
+
 * [Timing Diagrams](timing_diagrams.md)
 
 * Circuit Elements
-  * [CircuitVerse Outputs](outputs.md)
-  * [Standard Gates](gates.md)
+  
+  * [Input ](inputElements.md)
+  
+  * [Output ](outputs.md)
+  * [Gates](gates.md)
   * [Decoders and Plexers](decodersandplexers.md)
   * [Sequential Elements](Sequential.md)
+  * [Test Bench](testbench.md)
   * [Splitter](splitter.md)
-  * [Input Elements](inputElements.md)
   * [Miscellaneous](miscellaneous.md)
+  
 * [Annotation Elements](annotation.md)
 
 * [Groups](groups.md)
-* [Test Bench](testbench.md)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,7 +8,7 @@
 
 Select the circuit element type and drop on canvas or drag the object onto canvas.
 
-## Connecting wires
+## Connecting Wires
 
 [filename](/video/wire.mp4 ':include :type=video')
 

--- a/docs/inputElements.md
+++ b/docs/inputElements.md
@@ -4,7 +4,7 @@
 
 Contributing Authors: [@Kedar-K](https://github.com/Kedar-K)
 
-## contents
+## Contents
 
 * [Getting started](#getting-started)
 * [Input](#input)

--- a/docs/inputElements.md
+++ b/docs/inputElements.md
@@ -13,6 +13,7 @@ Contributing Authors: [@Kedar-K](https://github.com/Kedar-K)
 * [Ground](#ground)
 * [Constantval](#constantval)
 * [Stepper](#stepper)
+* [Random](#random)
 * [Counter](#counter)
 
 ## Getting Started


### PR DESCRIPTION
Aligned sidebar contents in accordance with the simulator and minor changes

#### Describe the changes you have made -
I have made changes on the sidebar to make it contents in accordance with the simulator contents for easy navigation through the docs and also some minor changes on other files
#### Screenshots of the changes (If any) -
<img width="216" alt="3" src="https://user-images.githubusercontent.com/42991063/57173324-a74eb080-6e4d-11e9-935c-97113e283abf.PNG">
<img width="189" alt="4" src="https://user-images.githubusercontent.com/42991063/57173325-a74eb080-6e4d-11e9-9c78-550cc204ac5f.PNG">
