### PR TITLE
Fixing Broken links in docs

### DIFF
--- a/docs/Modify.md
+++ b/docs/Modify.md
@@ -6,12 +6,13 @@
 
 Click on any circuit element and see it's property menu at the bottom left corner.
 
-![Property Menu](/images/property_menu.png)
+![Property Menu](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/property_menu.png)
 
 ## Direction
 
 Modify the element direction by changing it in the property menu or simply use arrow keys.
-![Direction Change](/images/direction.png)
+
+![Direction Change](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/direction.png)
 
 ## Bitwidth
 
@@ -28,4 +29,5 @@ You can change other attributes, like the number of inputs of an AndGate in the 
 ## Label and Label Direction
 
 You can label any circuit element in the property menu. You can also chose the position of the label.
-![Direction Change](/images/label.png)
+
+![Label Direction](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/label.png)

--- a/docs/annotation.md
+++ b/docs/annotation.md
@@ -6,17 +6,17 @@
 ## Adding Labels
 
 You can label any circuit element using the property menu. You can also chose the position of the label.
-![Direction Change](/images/label.png)
+![Direction Change](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/label.png)
 
 ## Creating Titles
 
 You can title the circuit using the Text feature present under Misc.
-![Text Location](/images/text-location.png)
+![Text Location](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/text-location.png)
 
 
 An example showing properly annotated Full Adder Circuit
 
-![Annotation Example](/images/annotation-example.png)
+![Annotation Example](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/annotation-example.png)
 
 > Also, you can add details in your circuit, to help further convey the logic, highlight specific points, or explain the flow of circuit, using the Text feature. <br/>
 > Circuitverse also provides you with two more features to annotate your circuit namely **Arrow** and **Rectangle**.
@@ -25,13 +25,10 @@ An example showing properly annotated Full Adder Circuit
 
 Just navigate through `Misc -> Arrow` and just drag & drop it to the required place. Also, you can change it's direction either by using the arrow keys on your keyboard or using the properties menu.
 
-![Arrow Location](/images/arrow-navigate.png)
+![Arrow Location](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/arrow-navigate.png)
 
 ## Rectangle
 
 If you ever feel the need to highlight or mark a specific portion of your circuit, you can use *Rectangle*, by navigating through `Misc -> Rectangle` and just drag & drop it to the required place. You can change its dimensions by using the properties menu.
 
-![Rectangle Location](/images/rectangle_navigate.png)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;     ![Properties Menu](/images/properties_rect.png)
-
-
-
+![Rectangle Location](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/rectangle_navigate.png)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;     ![Properties Menu](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/properties_rect.png)

--- a/docs/export.md
+++ b/docs/export.md
@@ -6,12 +6,13 @@
 
 To export a circuit as image go to tools &rightarrow; download Image.
 
-![Subcircuit Menu](/images/render_options.png)
+![Subcircuit Menu](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/render_options.png)
 
 ## Various rendering options
 
 Full circuit view will tell CircuitVerse, to zoom out so as to fit the screen and then export the image.
 Current View will export the image exactly how it is currently. This feature is not available for SVGs.
 
-![CS-SAP](/images/CS-SAP.png)
+![CS-SAP](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/CS-SAP.png)
+
 Control Sequencer of SAP-1 exported in high resolution.

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -19,7 +19,7 @@ Students can :
 
 - First Click on your username on the right top corner as shown.
 
-![My-Groups](/images/my-groups.png)
+![My-Groups](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/my-groups.png)
 
 - Then, Click on **New Group** Button to create a New Group.
 
@@ -27,7 +27,7 @@ Students can :
 - You can add students by clicking on the  **Add member** button.
 - Simply enter the list of emails separated by commas. (If students are already registered with CircuitVerse they will be added automatically. If they are not registered with CircuitVerse yet, an invitation will be sent to register. Once they register, they will be added automatically. )
 
-![Add-students](/images/students-list.png)
+![Add-students](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/students-list.png)
 
 ## Posting Assignments
 
@@ -40,7 +40,7 @@ Students can :
 
 > **NOTE :** Word Processing tools are available for Description as well as feature to embed Any File for Assignment Description.
 
-![Assigments](/images/assignment.png)
+![Assigments](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/assignment.png)
 
 > After Posting, to see the status of different assignments, Click on the **Show** button correspoding to a group.
 <br/>
@@ -50,7 +50,7 @@ Students can :
 
 >To see the students' work in each assignment, click on **show** button corresponding to an Assignment.
 
-![student-stauts](/images/student-status.png)
+![student-stauts](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/student-status.png)
 
 ## For Students
 
@@ -66,7 +66,7 @@ Students can :
 <br/>
 > **Start Working** Button : It Would Open a New Window.
 
-![groups-student](/images/groups-student.png)
+![groups-student](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/groups-student.png)
 
 ***In Start Working Window,***
  - To Work Upon a Assignment, Launch simulator from **Launch Simulator** Button. Complete the assignment in simulator and save the work.

--- a/docs/memoryElements.md
+++ b/docs/memoryElements.md
@@ -15,7 +15,9 @@ or by selecting the component and pressing the "Reset" button in the properties 
 The contents of the RAM can be dumped to the console by transitioning CORE DUMP pin to 1
 or by selecting the component and pressing the "Core Dump" button in the properties window.
 Address spaces that have not been written will show up as undefined in the core dump.
-![RAM](images\ram.png)
+
+![RAM](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/ram.png)
+
 <iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/12515" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
 
 ## ROM

--- a/docs/subcircuit.md
+++ b/docs/subcircuit.md
@@ -6,14 +6,14 @@
 
 Create a circuit (circuit1) with inputs and outputs. Insert another circuit (Circuit &rightarrow; new circuit). Let's call this circuit 2. Then to insert circuit1 as a subcircuit in circuit 2, go to Circuit &rightarrow; insert Subcircuit. That is how you insert a subcircuit.
 
-![Subcircuit Menu](/images/subcircuit.png)
+![Subcircuit Menu](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/subcircuit.png)
 
 ## Editing layout of a subcircuit
 
 To edit the layout of the circuit, click on an empty space to see the property menu of the current circuit. Then click on edit layout.
 
-![Property Menu](/images/property_layout.png)
+![Property Menu](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/property_layout.png)
 
 You should be able to see a window where you can change the width, height of all the subcircuit. Position the title of the subcircuit. To change the position of the node, simple drag on a node and place it where you wish. Please note that a node can only be placed on the perimeter of the subcircuit.
 
-![Subcircuit Layout](/images/subcircuit_layout.png)
+![Subcircuit Layout](https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/images/subcircuit_layout.png)


### PR DESCRIPTION
Fixes #https://github.com/CircuitVerse/CircuitVerseDocs/issues/134
GCI task link : https://codein.withgoogle.com/dashboard/task-instances/6217892190748672/

#### Describe the changes you have made -

- iframe contents have been left as such.
- Fixed broken links

#### Screenshots of the changes (If any) -
