### PR TITLE
[GCI] #459 Find and Fix Typos

### DIFF
--- a/docs/Modify.md
+++ b/docs/Modify.md
@@ -15,7 +15,7 @@ Modify the element direction by changing it in the property menu or simply use a
 
 ## Bitwidth
 
-Modify the bitwidth of the circuit element in the property menu.
+Modify the BitWidth of the circuit element in the property menu.
 
 <iframe width="300px" height="200px" src="https://circuitverse.org/simulator/embed/736" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
 
@@ -27,5 +27,5 @@ You can change other attributes, like the number of inputs of an AndGate in the 
 
 ## Label and Label Direction
 
-You can label any circuit element in the property menu. You can also chose the position of the label.
+You can label any circuit element in the property menu. You can also choose the position of the label.
 ![Direction Change](/images/label.png)

--- a/docs/decodersandplexers.md
+++ b/docs/decodersandplexers.md
@@ -63,7 +63,7 @@ Its live circuit is embedded below:
 
 A bit-selector's function is self-explanatory. It takes a single or multi-bit input and gives the bit we desire to isolate as output. This is done using a single or multi-bit select line. The select line value indicates the specific bit we wish to isolate. An added feature is the bit-selector shows the bit we want to isolate (as chosen using the select line) within it's body in decimal form.
 
-Consider a bit selector with a four-bit input. Let each of it's bits be addressed separately as T3, T2, T1, T0 (from most significant to least significant). Let it have a two-bit select line (S1 and S0) and a single-bit output (Out). The truth table is given below:
+Consider a bit selector with a four-bit input. Let each of its bits be addressed separately as T3, T2, T1, T0 (from most significant to least significant). Let it have a two-bit select line (S1 and S0) and a single-bit output (Out). The truth table is given below:
 
 |    S1   |    S0   |   Out   |   
 |---------|---------|---------|
@@ -93,7 +93,7 @@ Consider an LSB detector with a four-bit input. Its live circuit is embedded bel
 
 ## Priority Encoder
 
-The priority encoder provided by Circuitverse works in a similar fashion to the MSB detector (in practise it can work like the LSB detector also). There is a specific output based on the bit position of the MSB, irrespective of the lesser significant bits. AN enable input is also provided to activate/deactivate the priority encoder. If there are N outputs, there will be 2^N inputs.
+The priority encoder provided by Circuitverse works in a similar fashion to the MSB detector (in practice it can work like the LSB detector also). There is a specific output based on the bit position of the MSB, irrespective of the lesser significant bits. AN enable input is also provided to activate/deactivate the priority encoder. If there are N outputs, there will be 2^N inputs.
 
 Consider a priority encoder with four single-bit inputs (T3, T2, T1 and T0 from most to least-significant bit) and two single-bit outputs (O2 and O1 from most to least-significant bit). The truth table is given below:
 
@@ -104,7 +104,7 @@ Consider a priority encoder with four single-bit inputs (T3, T2, T1 and T0 from 
 |    0    |    1    |    X    |    X    |    1    |    0    |
 |    1    |    X    |    X    |    X    |    1    |    1    |
 
-Its live circuit is emeded below:
+Its live circuit is embedded below:
 <iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/762" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
 
 ## Decoder
@@ -120,6 +120,6 @@ Consider a decoder with a single two-bit input (T1 and T0 from most to least-sig
 |    1    |    0    |    0    |    1    |    0    |    0    |
 |    1    |    1    |    1    |    0    |    0    |    0    |
 
-Its live circuit is emeded below:
+Its live circuit is embedded below:
 
 <iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/763" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -57,10 +57,10 @@ Students can :
 > Students can Manage their assignments from the **My Groups** Window.
 
 - Different groups Must be visible which are created by Their Teachers in **Groups You belong to** Window.
-- After Clicking On Particular Group, Few things are noticeable such as,
+- After Clicking On a particular group, few things are noticeable such as:
     - All the group members
     - List of Assignments with their respective deadline.
-    - Two Clickable like **show** and **Start Working**.
+    - Two Clickables like **show** and **Start Working**.
 
 > **Show** Button : Desription of the Assigment.
 <br/>

--- a/docs/inputElements.md
+++ b/docs/inputElements.md
@@ -60,7 +60,7 @@ The example above has LED's arranged in the form of "HI". These LED's will alway
 
 Occasionally, particularly in AC power distribution and some radio antenna systems, it does mean "a connection to the earth".
 
-However, in most electronics, particularly portable battery-operated devices, "ground" is just the point in the circuit that the designer chose to call "zero volts" and to use as a reference when measuring voltages elsewhere in the circuit. Hence, it is just similar to power but always Low(0).
+However, in most electronics, particularly portable battery-operated devices, "ground" is just the point in the circuit that the designer chooses to call "zero volts" and to use as a reference when measuring voltages elsewhere in the circuit. Hence, it is just similar to power but always Low(0).
 
 ## ConstantVal
 
@@ -68,7 +68,7 @@ The ConstantVal component can be used when there is a need to input some constan
 
 ![sef](./images/constantVal.gif)
 
-The value of constantval can be changed by double-clicking the component and entering the value in the prompt.
+The value of ConstantVal can be changed by double-clicking the component and entering the value in the prompt.
 
 ## Stepper
 

--- a/docs/miscellaneous.md
+++ b/docs/miscellaneous.md
@@ -26,7 +26,7 @@ There are Different ports in an ALU :
 >Input Values ( Opcodes ) for **ctr** are discussed in the later section.
 
 - Cout (status output) : This is an OUTPUT port for getting **carry** after the operation on given operands.
-- Ans : As name suggests, Output of **Result** after the operation on given operands.
+- Ans : As the name suggests, Output of **Result** after the operation on given operands.
 
 **STEPS FOR USAGE** :
 > Location of ALU : Under the **Misc** section.

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -78,4 +78,4 @@ The sixteen segment display takes two inputs and a total of 17 bits: 16 bits in 
 You can test out different inputs for yourself:
 <iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/11319" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
 
-There are both advantages and disadvantages to using the sixteen segment display as opposed to the hex and seven segment displays. The main advantage is that the greater number of segments allow you to create more detailed and clear numbers and letters. However, it requires double the input of the seven segment display and quadruples the input of the hex display, so it is significantly more complicated to work with.
+There are both advantages and disadvantages to using the sixteen segment display as opposed to the hex and seven segment displays. The main advantage is that the greater number of segments allow you to create more detailed and clear numbers and letters. However, it requires double the input of the seven segment display and quadruple the input of the hex display, so it is significantly more complicated to work with.

--- a/docs/saving_project.md
+++ b/docs/saving_project.md
@@ -4,7 +4,7 @@
 
 Contributing Authors: [@amansingla97](https://github.com/amansingla97/)
 ## Save Online
-This option allows the user to save the project with CircuitVerse cloud. While saving the project the user can also provide the description along with relevant tags related to the project.
+This option allows the user to save their project with the CircuitVerse cloud. While saving the project the user can also provide a description along with relevant tags related to the project.
 The project can also be saved with public, private or limited access.
 
 ![](./images/save_online.gif)

--- a/docs/timing_diagrams.md
+++ b/docs/timing_diagrams.md
@@ -22,7 +22,7 @@ You will now see the visualizer at the bottom of your screen, which shows the ti
 
 #### Changing the name of the Flag
 
-By default the flags are named as F1, F2 and so on, this can be confusing when you are dealing with a lot of signals. To change the name of the flag:
+By default the flags are named as F1, F2 and so on. This can be confusing when you are dealing with a lot of signals. To change the name of the flag:
 
 1. Click on the flag
 


### PR DESCRIPTION
Fixes [#459](https://github.com/CircuitVerse/CircuitVerse/issues/459)

#### Describe the changes you have made -
Fixed some typos and grammatical errors present in the Documentation.
