### PR TITLE
Stopped dark mode switch changing when clicking anchor links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -52,18 +52,20 @@
 			plugins: [
 				EditOnGithubPlugin.create('https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/'),
 				function(hook) {
-      var footer = [
-        
-        '<header>',
-       '<span><label class="switch"><input title="Toggle Dark theme" onclick="setStyleSheet();" type="checkbox"><span class="slider round"></span></label></span>',
+					var header = [
+						'<header">',
+						'<span><label class="switch"><input title="Toggle Dark theme" onclick="setStyleSheet();" type="checkbox"><span class="slider round"></span></label></span>',
+						'</header>'
+					].join('');
 
-          '</header>'
-      ].join('');
+					hook.afterEach(function(html) {
+						return header + html;
+					});
 
-      hook.afterEach(function(html) {
-        return footer + html;
-      });
-    }
+					hook.doneEach(function(html) {
+						pageLoaded();
+					});
+				}
 			],
 			loadSidebar: true,
 			maxLevel: 4,
@@ -99,6 +101,13 @@
 	gtag('js', new Date());
 
 	gtag('config', 'UA-112678513-2');
+	
+	function pageLoaded() {
+		console.log(stylesheet.getAttribute('href'), url, url2);
+		if (stylesheet.getAttribute('href') == url) { // if in dark mode
+			document.getElementsByClassName("switch")[0].childNodes[0].checked = true;
+		}
+	}
 </script>
 
 </html>


### PR DESCRIPTION
Fixes https://github.com/CircuitVerse/CircuitVerse/issues/657

#### Describe the changes you have made:

Added a function that stops the dark mode switch flipping (which side means light and which means dark switches) when an anchor link is pressed.