### PR TITLE
Fix Dark Mode toggler overlapping

### DIFF
--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -70,3 +70,9 @@ input:checked + .slider:before {
 .search {
   margin-top: 39px;
 }
+
+@media (max-width: 768px) {
+  .switch {
+    margin-right: 5%;
+  }
+}


### PR DESCRIPTION
Fixes #177

Describe the changes you have made -
After resizing the window size to 768px or less horizontally, the dark mode toggler gets overlapped by the Github corner logo now it is fixed to not overlap by adding some padding.

Screenshots of the changes (If any) -
Before:
![2020-01-05](https://user-images.githubusercontent.com/58560983/71778985-1c284a80-2fda-11ea-84d5-4f08cda9b856.png)

After:
![2020-01-05 (2)](https://user-images.githubusercontent.com/58560983/71778983-1b8fb400-2fda-11ea-8bfa-36e2d4613f5f.png)