### PR TITLE
Fixed slider overlapping by GitHub SVG in Mobile View.

### DIFF
--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -54,7 +54,7 @@ input:checked + .slider:before {
   transform: translateX(26px);
 }
 
-div[style="overflow:auto"]{
+div[style="overflow: auto"]{
   margin-top: 15px;
 }
 

--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -4,7 +4,7 @@
   width: 50px;
   height: 25px;
   margin-left: 15px;
-  margin-top: 12px;
+  margin-top: 30px;
   float: right;   
 }
 
@@ -52,6 +52,10 @@ input:checked + .slider:before {
   -webkit-transform: translateX(26px);
   -ms-transform: translateX(26px);
   transform: translateX(26px);
+}
+
+div[style="overflow:auto"]{
+  margin-top: 15px;
 }
 
 /* Rounded sliders */


### PR DESCRIPTION
Fixes #
Moved the slider and message "Edit on github" a little lower so that it isn't overlapped by the SVG.

#### Describe the changes you have made -
Added `margin-top` to the slider and the div containing "Edit on github" in `themes.css`.

#### Screenshots of the changes (If any) -
 **Before**

![Overlapped-Slider-Issue](https://user-images.githubusercontent.com/37783178/75437817-dc983200-597c-11ea-8784-60d29c37753f.gif)


**After**

![Overlapped-Slider-Fixed](https://user-images.githubusercontent.com/37783178/75437836-e457d680-597c-11ea-8087-3b5d29039b6c.gif)

Referencing Issue #177 