### PR TITLE
Slider reset#199

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
 
  <script>
 
-		var url =  "//unpkg.com/docsify/themes/dark.css";
+	var url =  "//unpkg.com/docsify/themes/dark.css";
     	var url2 = "//unpkg.com/docsify/themes/vue.css";
     	var stylesheet = document.getElementById("stylesheet");
     	var show = false;
@@ -62,40 +62,36 @@
 				function(hook) 
 				{
 
-			      var footer = [
-			        
-			        '<header>',
-			       '<span><label class="switch"><input title="Toggle Dark theme" onclick="setStyleSheet();" type="checkbox"><span class="slider round"></span></label></span>',
+				      var footer = [
+					'<header>',
+				       	'<span><label class="switch"><input title="Toggle Dark theme" onclick="setStyleSheet();" type="checkbox"><span class="slider round"></span></label></span>',
+					'</header>'
+				      ].join('');
 
-			          '</header>'
-			      ].join('');
-
-			      hook.afterEach(function(html) {
-			        return footer + html;
-			      });
-    			},
+				      hook.afterEach(function(html) {
+					return footer + html;
+				      });
+				},
 			],
 			loadSidebar: true,
 			maxLevel: 4,
 			subMaxLevel: 2,
 			alias: {
 				'/.*/_sidebar.md': '/_sidebar.md'
- 
 			},
 			executeScript:true,
 			auto2top: true,
 			pagination: {
-                              previousText: 'Previous',
+                             previousText: 'Previous',
                              nextText: 'Next',
-                             }
+                       	}
  
 		}
 	</script>
-	
 	 
 	<script src="//unpkg.com/docsify@4.7.1/lib/docsify.min.js"></script>
 	<script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
-    <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
+    	<script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
 	<script src="//unpkg.com/docsify/lib/plugins/zoom-image.min.js"></script>
 	<script type="text/javascript">
 
@@ -114,8 +110,7 @@
 			observer.observe(article, {
 				childList: true
 			});
-		}
-
+		};
 	</script>
 </body>
 <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,12 +20,19 @@
         <link rel="stylesheet" type="text/css" href="styles/theme.css">
 
  <script>
- 	        var url =  "//unpkg.com/docsify/themes/dark.css";
-        	var url2 = "//unpkg.com/docsify/themes/vue.css";
-        	var stylesheet = document.getElementById("stylesheet");
-        	var show = false;
+
+		var url =  "//unpkg.com/docsify/themes/dark.css";
+    	var url2 = "//unpkg.com/docsify/themes/vue.css";
+    	var stylesheet = document.getElementById("stylesheet");
+    	var show = false;
 
  	  function setStyleSheet() {
+ 	  			const slider = document.querySelector(".slider");
+ 	  			slider.classList.add("smooth");
+ 	  			setTimeout(function()
+ 	  			{
+ 	  				document.querySelector(".slider").classList.remove("smooth");
+ 	  			}, 500);
                  if (show) {
                         stylesheet.setAttribute('href', url2);
                            show = !show;
@@ -52,19 +59,21 @@
 
 			plugins: [
 				EditOnGithubPlugin.create('https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/'),
-				function(hook) {
-      var footer = [
-        
-        '<header>',
-       '<span><label class="switch"><input title="Toggle Dark theme" onclick="setStyleSheet();" type="checkbox"><span class="slider round"></span></label></span>',
+				function(hook) 
+				{
 
-          '</header>'
-      ].join('');
+			      var footer = [
+			        
+			        '<header>',
+			       '<span><label class="switch"><input title="Toggle Dark theme" onclick="setStyleSheet();" type="checkbox"><span class="slider round"></span></label></span>',
 
-      hook.afterEach(function(html) {
-        return footer + html;
-      });
-    }
+			          '</header>'
+			      ].join('');
+
+			      hook.afterEach(function(html) {
+			        return footer + html;
+			      });
+    			},
 			],
 			loadSidebar: true,
 			maxLevel: 4,
@@ -86,9 +95,28 @@
 	 
 	<script src="//unpkg.com/docsify@4.7.1/lib/docsify.min.js"></script>
 	<script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
-       <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
+    <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
 	<script src="//unpkg.com/docsify/lib/plugins/zoom-image.min.js"></script>
+	<script type="text/javascript">
 
+		window.onload = function()
+		{
+			const observer = new MutationObserver(function(mutations){
+			mutations.forEach(function(mutation){
+					if(stylesheet.getAttribute("href") === url)
+						document.querySelector("input[type='checkbox']").checked = true;
+					else
+						document.querySelector("input[type='checkbox']").checked = false;
+				});
+			});
+
+			const article = document.querySelector("#main");
+			observer.observe(article, {
+				childList: true
+			});
+		}
+
+	</script>
 </body>
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112678513-2"></script>
@@ -102,5 +130,4 @@
 
 	gtag('config', 'UA-112678513-2');
 </script>
-
 </html>

--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -54,7 +54,7 @@ input:checked + .slider:before {
   transform: translateX(26px);
 }
 
-div[style="overflow:auto"]{
+div[style="overflow: auto"]{
   margin-top: 15px;
 }
 

--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -4,7 +4,7 @@
   width: 50px;
   height: 25px;
   margin-left: 15px;
-  margin-top: 12px;
+  margin-top: 30px;
   float: right;   
 }
 
@@ -52,6 +52,10 @@ input:checked + .slider:before {
   -webkit-transform: translateX(26px);
   -ms-transform: translateX(26px);
   transform: translateX(26px);
+}
+
+div[style="overflow:auto"]{
+  margin-top: 15px;
 }
 
 /* Rounded sliders */

--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -24,11 +24,24 @@
   right: 0;
   bottom: 0;
   background-color: #ccc;
+}
+
+.smooth{
   -webkit-transition: .4s;
   transition: .4s;
 }
 
 .slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+}
+
+.slider.smooth:before {
   position: absolute;
   content: "";
   height: 16px;


### PR DESCRIPTION
Fixes #
Dark mode slider was resetting when a new article was loaded. Fixed the issue.

#### Describe the changes you have made -
Used a `MutationObserver` that keeps track of the `article` element. If any change occurs in the childList of the `article` then the current stylesheet is used to determine whether the slider checkbox should be checked or not. Changes corresponding to this have been made in `index.html`.

Also, slider transition animation only happens when the slider is clicked and not when the article is changed

. Changes corresponding to this have been made in `themes.css` and `index.html`.

#### Screenshots of the changes (If any) -

### Before

![Slider-Reset-Issue](https://user-images.githubusercontent.com/37783178/75525448-d914b180-5a35-11ea-9464-1be3c8b5883a.gif)

### After

![Slider-Reset-Fixed](https://user-images.githubusercontent.com/37783178/75525453-de71fc00-5a35-11ea-8031-397c8212b4e4.gif)


Should fix Issue #199 