### PR TITLE
Fixed redundant links issue 206

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<h1> Welcome to CircuitVerse </h1>
+# Welcome to CircuitVerse 
 
 > CircuitVerse is extremely easy for beginners and experienced alike. This documentation will help you get started quickly.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Welcome to CircuitVerse
+<h1> Welcome to CircuitVerse </h1>
 
 > CircuitVerse is extremely easy for beginners and experienced alike. This documentation will help you get started quickly.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
 	<div id="app"></div>
 	<script>
 		window.$docsify = {
-			// name: 'CircuitVerse Documentation',
+			name: 'CircuitVerse Documentation',
 			repo: 'https://github.com/CircuitVerse/CircuitVerseDocs/',
 
 			plugins: [
@@ -74,12 +74,14 @@
 				},
 			],
 			loadSidebar: true,
+			routerMode: 'history',
 			maxLevel: 4,
 			subMaxLevel: 2,
 			alias: {
 				'/.*/_sidebar.md': '/_sidebar.md'
 			},
 			executeScript:true,
+			noCompileLinks: ['/#'],
 			auto2top: true,
 			pagination: {
                              previousText: 'Previous',

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,8 +54,8 @@
 	<div id="app"></div>
 	<script>
 		window.$docsify = {
-			name: 'CircuitVerse Documentation',
-			repo: 'https://github.com/CircuitVerse/CircuitVerseDocs/',
+			// name: ' CircuitVerse Documentation ',
+			// repo: null,
 
 			plugins: [
 				EditOnGithubPlugin.create('https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/'),

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@
 				},
 			],
 			loadSidebar: true,
-			routerMode: 'hash',
+			routerMode: 'history',
 			maxLevel: 4,
 			subMaxLevel: 2,
 			alias: {

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@
 				},
 			],
 			loadSidebar: true,
-			routerMode: 'history',
+			routerMode: 'hash',
 			maxLevel: 4,
 			subMaxLevel: 2,
 			alias: {

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,8 +54,8 @@
 	<div id="app"></div>
 	<script>
 		window.$docsify = {
-			// name: ' CircuitVerse Documentation ',
-			// repo: null,
+			// name: 'CircuitVerse Documentation',
+			repo: 'https://github.com/CircuitVerse/CircuitVerseDocs/',
 
 			plugins: [
 				EditOnGithubPlugin.create('https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/'),


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made 
- I disabled the " ```Welcome to CircuitVerse``` link in ```README.md``` by replacing ```#``` for level 1 heading with ```h1```. 
- Disabled the 'CircuitVerse Documentation' link in ```index.html``` by changing the default ```routerMode: 'hash'``` to ```routerMode: 'history'```. Apparently the name property in docsify is hashed.



#### Screenshots of the changes (If any) - Only the home link works
![circuitVerse](https://user-images.githubusercontent.com/22575481/76818266-75480200-6805-11ea-95ff-47201bafd77c.PNG)

