### PR TITLE
Fixed overflow at phone, and tablet screens on Getting started page 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Welcome to CircuitVerse
+<h1> Welcome to CircuitVerse </h1>
 
 > CircuitVerse is extremely easy for beginners and experienced alike. This documentation will help you get started quickly.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,24 +4,33 @@
 
 ## Creating a Circuit Element
 
-[filename](/video/drag.mp4 ':include :type=video ')
+<video style="width:100%; height: 400px;" controls>
+    <source src="/video/drag.mp4" type="video/mp4">  Sorry, your browser doesn't support embedded videos.
+</video>
 
 Select the circuit element type and drop on canvas or drag the object onto canvas.
 
 ## Connecting wires
 
-[filename](/video/wire.mp4 ':include :type=video')
+<video style="width:100%; height: 400px;" controls>
+    <source src="/video/drag.mp4" type="video/mp4">  Sorry, your browser doesn't support embedded videos.
+</video>
+
 
 Click one node and simply drag the mouse to the other node.
 
 ## Multiple Object Selections
 
-[filename](/video/multiselectionDrag.mp4 ':include :type=video')
+<video style="width:100%; height: 400px;" controls>
+    <source src="/video/multiselectionDrag.mp4 " type="video/mp4">  Sorry, your browser doesn't support embedded videos.
+</video>
 
 Hold down shift key and drag to make a selection
 
 ## Property Menu
 
-[filename](/video/properties.mp4 ':include :type=video')
+<video style="width:100%; height: 400px;" controls>
+    <source src="/video/properties.mp4 " type="video/mp4">  Sorry, your browser doesn't support embedded videos.
+</video>
 
 Select the object to see and change its properties.

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
 	<div id="app"></div>
 	<script>
 		window.$docsify = {
-			// name: 'CircuitVerse Documentation',
+			name: 'CircuitVerse Documentation',
 			repo: 'https://github.com/CircuitVerse/CircuitVerseDocs/',
 
 			plugins: [
@@ -74,12 +74,14 @@
 				},
 			],
 			loadSidebar: true,
+			routerMode: 'history',
 			maxLevel: 4,
 			subMaxLevel: 2,
 			alias: {
 				'/.*/_sidebar.md': '/_sidebar.md'
 			},
 			executeScript:true,
+			noCompileLinks: ['/#'],
 			auto2top: true,
 			pagination: {
                              previousText: 'Previous',

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,8 +54,8 @@
 	<div id="app"></div>
 	<script>
 		window.$docsify = {
-			name: 'CircuitVerse Documentation',
-			repo: 'https://github.com/CircuitVerse/CircuitVerseDocs/',
+			// name: ' CircuitVerse Documentation ',
+			// repo: null,
 
 			plugins: [
 				EditOnGithubPlugin.create('https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/'),

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,8 +54,8 @@
 	<div id="app"></div>
 	<script>
 		window.$docsify = {
-			// name: ' CircuitVerse Documentation ',
-			// repo: null,
+			// name: 'CircuitVerse Documentation',
+			repo: 'https://github.com/CircuitVerse/CircuitVerseDocs/',
 
 			plugins: [
 				EditOnGithubPlugin.create('https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/'),


### PR DESCRIPTION
Fixes #215 

#### Describe the changes you have made 
- Replaced the markdown style of embedding videos to HTML format. 
```
<video style="width:100%; height: 400px;" controls>
    <source src="/video/drag.mp4" type="video/mp4">  Sorry, your browser doesn't support embedded videos.
</video>
```

#### Screenshots of the changes (If any) -
![127 0 0 1_5000_(iPad Pro)](https://user-images.githubusercontent.com/22575481/77470475-03794500-6e11-11ea-9946-1dc08243b2ea.png)
![127 0 0 1_5000_(iPhone X)](https://user-images.githubusercontent.com/22575481/77470878-acc03b00-6e11-11ea-989a-2f744ffc45de.png)


