### PR TITLE
Fix description of Priority Encoder Enable to 'Valid' output.

### DIFF
--- a/docs/decodersandplexers.md
+++ b/docs/decodersandplexers.md
@@ -93,16 +93,17 @@ Consider an LSB detector with a four-bit input. Its live circuit is embedded bel
 
 ## Priority Encoder
 
-The priority encoder provided by Circuitverse works in a similar fashion to the MSB detector (in practice it can work like the LSB detector also). There is a specific output based on the bit position of the MSB, irrespective of the lesser significant bits. AN enable input is also provided to activate/deactivate the priority encoder. If there are N outputs, there will be 2^N inputs.
+The priority encoder provided by Circuitverse works in a similar fashion to the MSB detector (in practice it can work like the LSB detector also). There is a specific output based on the bit position of the MSB, irrespective of the lesser significant bits. If there are N outputs, there will be 2^N inputs. A 'Valid' output labeled V is provided to indicate that at least one input is 1. Valid 0 output means none of the inputs are 1. Read the binary value of the output(s) to determine the input number of the highest input which is active. An example use of this circuit element is to indicate if any interrupt is present to a system, and to provide the value of the highest priority interrupt which is asserted.
 
 Consider a priority encoder with four single-bit inputs (T3, T2, T1 and T0 from most to least-significant bit) and two single-bit outputs (O2 and O1 from most to least-significant bit). The truth table is given below:
 
-|   T3    |   T2    |   T1    |   T0    |   O2    |   O1    |
-|---------|---------|---------|---------|---------|---------|
-|    0    |    0    |    0    |    1    |    0    |    0    |     
-|    0    |    0    |    1    |    X    |    0    |    1    |
-|    0    |    1    |    X    |    X    |    1    |    0    |
-|    1    |    X    |    X    |    X    |    1    |    1    |
+|   T3    |   T2    |   T1    |   T0    |    V    |   O2    |   O1    |
+|---------|---------|---------|---------|---------|---------|---------|
+|    0    |    0    |    0    |    0    |    0    |    0    |    0    |
+|    0    |    0    |    0    |    1    |    1    |    0    |    0    |
+|    0    |    0    |    1    |    X    |    1    |    0    |    1    |
+|    0    |    1    |    X    |    X    |    1    |    1    |    0    |
+|    1    |    X    |    X    |    X    |    1    |    1    |    1    |
 
 Its live circuit is embedded below:
 <iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/762" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>


### PR DESCRIPTION
Fixes https://github.com/CircuitVerse/cv-frontend-vue/issues/1080

#### Changes done:
This PR fixes the documentation in the online help for the Priority Encoder circuit element.  A separate PR to the CircuitVerse JavaScript code will fix the labeling of the circuit element's connection.

#### UI change?
No UI changes per say, however the owner of https://circuitverse.org/simulator/embed/762 should update it, removing the input on the lower left, and replacing it with an output on the lower right.

#### Preview Link:
https://github.com/nTrfAce/CircuitVerseDocs/blob/master/docs/decodersandplexers.md

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️ nope.  and CircuitVerse/CircuitVerse#165 can be closed
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
