### PR TITLE
removes additional bg-color for navbar on dark mode

### DIFF
--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -102,7 +102,6 @@ div[style="overflow: auto"]{
     margin-right: 5%;
   }
   body.close .sidebar-toggle{
-    background-color: white;
     width: 296px;
   }  
 }


### PR DESCRIPTION
Fixes #355

#### Changes done:
- [x] The white background color is removed for smaller screens (max-width : 768px)


#### Screenshots:
initial state of navbar (before changes) : 
![initial](https://github.com/CircuitVerse/CircuitVerseDocs/assets/136724527/8d6ee605-975b-43c8-b3d6-6a0838aec0b5)


final state of navbar (after changes) :
![final](https://github.com/CircuitVerse/CircuitVerseDocs/assets/136724527/e57a6eac-a26c-469b-a0f1-e5aeeca0264b)



#### Preview Link(s):  https://github.com/Murdock9803/CircuitVerseDocs/blob/e888a3fd1fbbc67ca6588877081afff40531539a/docs/styles/theme.css


#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
