### PR TITLE
fix #366: put a gap between `table heading` and `table content`

### DIFF
--- a/docs/chapter4/5muxandplex.md
+++ b/docs/chapter4/5muxandplex.md
@@ -856,7 +856,9 @@ Table 4.10: Truth table for an even three-bit parity detector
   </tr>
 </table>
 <br>
+
 Table 4.11: Truth table for an odd 3-bit parity detector
+
 <table>
   <tr>
    <td><strong>A</strong>

--- a/docs/chapter8/1onlineforums.md
+++ b/docs/chapter8/1onlineforums.md
@@ -2,5 +2,5 @@
 
 *   CircuitVerse Forum: [https://circuitverse.org/forum](https://circuitverse.org/forum)
 *   CircuitVerse on GitHub: [https://github.com/CircuitVerse](https://github.com/CircuitVerse) 
-*   CircuitVerse on Slack:<span style="text-decoration:underline;"> [https://circuitverse-team.slack.com](https://circuitverse-team.slack.com) </span>
+*   CircuitVerse on Slack: [https://circuitverse-team.slack.com](https://circuitverse-team.slack.com) </span>
 *   CircuitVerse YouTube Channel: [https://www.youtube.com/channel/UCAK48dCPc_QON6Y5QqqRLOg](https://www.youtube.com/channel/UCAK48dCPc_QON6Y5QqqRLOg) 


### PR DESCRIPTION
### Issue link: https://github.com/CircuitVerse/CircuitVerseDocs/issues/366
## Description:
There is a single line gap between the table heading and table content everywhere. But in ``table 4.11`` there is no gap.
To fix this, I Put a gap between the table heading and table content in ``Table 4.11``
## Screenshots:
### Before:
![Screenshot (1055)](https://github.com/CircuitVerse/CircuitVerseDocs/assets/99977240/2d5f07c5-d06c-4836-aaf9-43414d905e6e)
### After:
![Screenshot (1054)](https://github.com/CircuitVerse/CircuitVerseDocs/assets/99977240/44682f3e-8ce8-4a4f-a0a3-7e47ff00565d)
#### ✅️ By submitting this PR, I have verified the following
- [X] Checked to see if a similar PR has already been opened 🤔️
- [X] Reviewed the contributing guidelines 🔍️
- [X] Sample preview link added (add a link from the checks tab after checks complete)
- [X] Tried Squashing the commits into one
