### PR TITLE
fix #366: put a gap between table heading and table content

### DIFF
--- a/docs/chapter4/5muxandplex.md
+++ b/docs/chapter4/5muxandplex.md
@@ -855,7 +855,7 @@ Table 4.10: Truth table for an even three-bit parity detector
    </td>
   </tr>
 </table>
-<br>
+
 Table 4.11: Truth table for an odd 3-bit parity detector
 <table>
   <tr>


### PR DESCRIPTION
### Issue link: https://github.com/CircuitVerse/CircuitVerseDocs/issues/366
## Description:
There is a single line gap between the table heading and table content everywhere. But in table 4.11 there is no gap.
To fix this, I Put a gap between the table heading and table content in Table 4.11
### Screenshots:
### Before:
![Screenshot (1055)](https://github.com/CircuitVerse/CircuitVerseDocs/assets/99977240/df1ee91c-ad56-478c-acc1-3dfc6d29c3f7)
### After:
![Screenshot (1054)](https://github.com/CircuitVerse/CircuitVerseDocs/assets/99977240/6450f15f-3cad-4f5d-8fbc-a8c6a20488d7)
✅️ By submitting this PR, I have verified the following
- [X] Checked to see if a similar PR has already been opened 🤔️
 - [X] Reviewed the contributing guidelines 🔍️
 - [X] Sample preview link added (add a link from the checks tab after checks complete)
 - [X] Tried Squashing the commits into one