### PR TITLE
Correct description of "En" output for Priority Encoder

### DIFF
--- a/docs/chapter4/5muxandplex.md
+++ b/docs/chapter4/5muxandplex.md
@@ -278,7 +278,9 @@ You can verify the behavior of the **Least Significant Bit (LSB)** detector circ
 
 ## Priority Encoder
 
-The **Priority Encoder** circuit element works similarly to the **MSB and LSB **detector. There is a specific output based on the bit position of the MSB, irrespective of the lesser significant bits. An enable input is also provided to activate/deactivate the priority encoder. If there are N outputs, there will be 2^N inputs.
+The **Priority Encoder** circuit element works similarly to the **MSB and LSB **detector. There is a specific output based on the bit position of the MSB, irrespective of the lesser significant bits. If there are N outputs, there will be 2^N inputs.
+
+There is also an output labeled "EN", which is 1 when the input is valid (e.g., not all zero).
 
 In the live circuit embedded below, a **Priority Encoder** with four single-bit inputs (T3, T2, T1 and T0 from most to least-significant bit) and two single-bit outputs (O2 and O1 from most to least-significant bit). Table 4.6 displays the truth table of the four-input priority encoder.
 
@@ -299,6 +301,24 @@ Table 4.6 : Truth table of a four-input priority encoder
    </td>
    <td><strong>O1</strong>
    </td>
+   <td><strong>EN</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>0
+   </td>
+   <td>0
+   </td>
+   <td>0
+   </td>
+   <td>0
+   </td>
+   <td>0
+   </td>
+   <td>0
+   </td>
+   <td>0
+   </td>
   </tr>
   <tr>
    <td>0
@@ -313,24 +333,28 @@ Table 4.6 : Truth table of a four-input priority encoder
    </td>
    <td>0
    </td>
-  </tr>
-  <tr>
-   <td>0
-   </td>
-   <td>0
-   </td>
-   <td>1
-   </td>
-   <td>X
-   </td>
-   <td>0
-   </td>
    <td>1
    </td>
   </tr>
   <tr>
    <td>0
    </td>
+   <td>0
+   </td>
+   <td>1
+   </td>
+   <td>X
+   </td>
+   <td>0
+   </td>
+   <td>1
+   </td>
+   <td>1
+   </td>
+  </tr>
+  <tr>
+   <td>0
+   </td>
    <td>1
    </td>
    <td>X
@@ -341,6 +365,8 @@ Table 4.6 : Truth table of a four-input priority encoder
    </td>
    <td>0
    </td>
+   <td>1
+   </td>
   </tr>
   <tr>
    <td>1
@@ -350,6 +376,8 @@ Table 4.6 : Truth table of a four-input priority encoder
    <td>X
    </td>
    <td>X
+   </td>
+   <td>1
    </td>
    <td>1
    </td>


### PR DESCRIPTION
The "En" port was described as an input to the priority encoder, when really it is an output that indicates whether the input is not all zero (and hence the outputs Tn are not meaningful).

The circuit shown in the iframe also needs to be updated, but I cannot do that. Right now, it connects an input to the En port, which triggers a contention error.

Ref [CircuitVerse#1718](https://github.com/CircuitVerse/CircuitVerse/pull/1718): This issue was spotted quite a while ago, but the proposed fix changed the name of the output port, and was rejected. This change merely documents the status quo, which I think is necessary - multiple students of mine were confused by the documentation!

#### Changes done:
- [x] Update the documentation to match the actual behavior of the priority encoder (see above).

#### Screenshots:
Not applicable.

#### Preview Link(s):
https://github.com/TobiasKappe/CircuitVerseDocs/blob/897f909b1fef934241372fcca955d089a848846d/docs/chapter4/5muxandplex.md#priority-encoder

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened (there's #276, which is in conflict with master, and is not getting merged on account of the accompanying PR to CircuitVerse being rejected)
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
