### PR TITLE
Removed the gif error in the Understanding Error Message page

### DIFF
--- a/docs/chapter8/3cverrormessages.md
+++ b/docs/chapter8/3cverrormessages.md
@@ -11,6 +11,7 @@
 
 2. **Contention Error 1 and 0**: When the circuit is driven by two or more outputs of both HIGH and LOW, the simulator may display this error. 
 
-    ![Contention Error 1 and 0](https://i.stack.imgur.com/xW0lC.gif)
+    ![Contention Error 1 and 0](https://qph.cf2.quoracdn.net/main-qimg-ecf6607d961cd423e3104917db9ff19c)
+    ![Contention Error](https://qph.cf2.quoracdn.net/main-qimg-77c8e38932aadfbaf79d99eb65496788)
 
 **Resolution:** Logic contention errors indicate a circuit design problem leading to large amounts of power to flow across circuit elements. Revisit your design for some wiring errors or for active multiple output enable lines that are driving a bus or circuit node simultaneously.


### PR DESCRIPTION

Fixes #402 

#### Changes done:
1. Earlier StackOverflow embedded gif link(not working) has been replaced by Quora gif link.
2. Another gif link was added for clarity regarding contention error.


#### Screenshots:
Before:

![Screenshot from 2025-03-12 17-01-40](https://github.com/user-attachments/assets/24b70da8-e910-4121-ba4f-19d14beb2afd)

After:
![Screenshot from 2025-03-12 17-26-14](https://github.com/user-attachments/assets/f5d9617e-7706-4b54-a4cf-e1486787c31f)

