### PR TITLE
Fix: Resolved issue #407

### DIFF
--- a/docs/chapter3/2understandingcvsimulator.md
+++ b/docs/chapter3/2understandingcvsimulator.md
@@ -84,7 +84,13 @@ Table 3.1: Different sections of the CircuitVerse simulator
 
 While the **CIRCUIT ELEMENTS** panel, **PROPERTIES** panel and the quick access panel can be easily moved around the screen, the **CIRCUIT ELEMENTS** panel and the **PROPERTIES** panel are collapsible panels.
 
-<div><iframe>Insert customize video panels video</iframe></div>
+<div align="center">
+ <video width="800" controls preload="auto">
+    <source src="../images/img_chapter3/3.24.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+</video>
+
+</div>
 
 Click on the relevant links to learn more about a given section:
 


### PR DESCRIPTION
## Issue Resolved
Fixes #407

## Changes Made
- Added the missing video (`3.24.mp4`) in **Chapter 3: Simulator Interface**, section **"Understanding CircuitVerse Simulator"**.
- Video is now located in:  
  `../images/img_chapter3/3.24.mp4`
- Updated the documentation file to reference the newly added video.
- Ensured that the video properly loads and provides visual guidance for users.

## How to Verify
1. Check that the video file exists in `./images/img_chapter3/3.24.mp4`.
2. Open `docs/chapter3/2understandingcvsimulator.md` and confirm that the video is correctly linked.
3. Run `python -m http.server` and navigate to the page.
4. Verify that the video appears and plays correctly.

## Screenshot

![Screenshot 2025-03-29 121340](https://github.com/user-attachments/assets/6f882cbb-93f7-4f54-bf7d-325a85f8faac)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the CircuitVerse simulator documentation to replace an embedded preview with a native video player. The new video is centered on the page and features built-in controls, preloading functionality, and a fallback message for browsers that do not support the video display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->