### PR TITLE
fix: Broken link for best practices page. (Issue 409)

### DIFF
--- a/docs/chapter7/1cvdesignprocess.md
+++ b/docs/chapter7/1cvdesignprocess.md
@@ -5,5 +5,5 @@ CircuitVerse simulator allows users to build and simulate their designs on the g
 
 Finally, the circuit schematic must be annotated using the different annotation elements available in the **PROPERTIES** panel. Any questions or suggestions can be shared with the CircuitVerse Forum where CircuitVerse mentors and a growing community of users can answer your queries or share quick workarounds.
 
-For best practices of building circuits within CircuitVerse, [refer this section](/chapter2/3bestpracticescv.md).
+For best practices of building circuits within CircuitVerse, [refer this section](/chapter2/4bestpracticescv.md).
 


### PR DESCRIPTION
<!-- Thank you for contributing to this repository, it is much appreciated! Make sure that you follow this template strictly, Pull requests won't be merged if the template is not properly filled.

Also keep in mind that the maintainers get notifications of all events on the repository, therefore avoid unnecessary mentions when opening pull requests. Else, feel free to ask queries or for support.
-->


<!--
It's always a good practice to accompany a pull request with an issue. Use either of the two mentioned below. Remove the one you are not using.
- use "Fixes" only when the pull request completely satisfies the issue
- use "Ref" only when the pull request partially satisfies the issue
-->
Fixes Issue #409:  Broken Link on Understanding CircuitVerse Design Process Page. Earlier it used to point to incorrect page which doesn't exists.


<!-- what all has been done in this pull request -->
#### Changes done:
- [x] Task 1: Changed URL to Best practices page in chapter7/1cvdesignprocess.md page 


<!-- Preview links of all the files that have been changed/updated -->


<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [ ] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated a hyperlink in the documentation to point to the current best practices reference for circuit building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->