### PR TITLE
issue #218 docs: add practical usage explanation for Delay property

### DIFF
--- a/docs/chapter6/delayvsclock.md
+++ b/docs/chapter6/delayvsclock.md
@@ -35,3 +35,28 @@ The below design restrictions have been implemented in the CV simulator to ease 
 2. Similarly, circuits go into a stable state before processing input signals from different input elements like buttons and stepper.
 3. Contamination delay = Propagation delay
 4. Hold time = 0
+
+### Practical Usage in the Simulator
+
+The Delay property controls *when* a signal transition appears at the
+output of a component, not *what* value is produced.
+
+When a Delay is applied:
+- An input transition occurs immediately
+- The corresponding output transition is scheduled after the specified delay
+
+This behavior becomes clearly visible when using the **Timing Diagram**
+or when Delay is applied to output components such as LEDs.
+
+#### Example
+
+- Input changes from `0` to `1` at time `t`
+- Output updates at time `t + Delay`
+
+The logical value remains unchanged; only the timing of the update is
+affected.
+
+#### Notes
+
+- Delay does not modify the logic of the circuit
+- Delay only affects signal propagation time


### PR DESCRIPTION
## Description
The Delay property is documented from a theoretical perspective, but
there is no practical explanation of how it affects component behavior
in the simulator UI.

This PR adds a "Practical Usage" subsection explaining:
- How Delay affects signal propagation timing
- What users observe when Delay is applied to output components
- How Delay relates to the timing diagram

This improves clarity for beginners and bridges the gap between theory
and simulator behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added practical usage guidance for understanding Delay functionality in the simulator
  * Included clear examples showing how signal transitions propagate with delays (e.g., input transition at time t produces output transition at t + Delay value)
  * Clarified that Delay affects only propagation timing and does not modify logical signal values or circuit logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->