### PR TITLE
docs: fix typo 'scoll' to 'scroll' in keyboard shortcuts documentation

### DIFF
--- a/docs/chapter8/4shortcuts.mdx
+++ b/docs/chapter8/4shortcuts.mdx
@@ -17,7 +17,7 @@ description: "Shortcuts page in Chapter8 of CircuitVerse documentation."
 | Select All                      |         Ctrl + a         |
 | De-select                       |           ESC            |
 | Deattach objects before placing |        Backspace         |
-| Multi-object Select             | Ctrl + scoll using mouse |
+| Multi-object Select             | Ctrl + scroll using mouse |
 | Save Project Online             |         Ctrl + s         |
 | Save Project Offline            |     Ctrl + Shift + s     |
 | Open Project                    |         Ctrl + o         |


### PR DESCRIPTION
Fixes #458 
## Changes done:
- ✅ Fixed typo in [docs/chapter8/4shortcuts.mdx](cci:7://file:///d:/VsCode/CircuitVerseDocs/docs/chapter8/4shortcuts.mdx:0:0-0:0) (line 20)
- ✅ Changed "scoll" to "scroll" in the Multi-object Select keyboard shortcut description
## Screenshots:
<img width="2836" height="1623" alt="Screenshot 2025-12-14 132919" src="https://github.com/user-attachments/assets/3bb471ba-9f90-49e5-896f-00fbbd239d41" />

## Preview Link(s):
Will be added after checks complete from Netlify preview deployment

## By submitting this PR, I have verified the following:
- [x] Checked to see if a similar PR has already been opened
- [x] Reviewed the contributing guidelines
- [ ] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the Multi-object Select shortcut documentation for improved accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->