### PR TITLE
fix: improve capitalization and grammar in sidebar labels

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -26,10 +26,10 @@ const sidebars = {
       label: 'Chapter 2: Getting Started with CircuitVerse',
       items: [
         { type: 'doc', id: 'chapter2/chapter2-gettingstarted', label: 'Getting Started' },
-        { type: 'doc', id: 'chapter2/chapter2-cvforeducators', label: 'CircuitVerse For Educators' },
+        { type: 'doc', id: 'chapter2/chapter2-cvforeducators', label: 'CircuitVerse for Educators' },
         { type: 'doc', id: 'chapter2/chapter2-lmsintegration', label: 'Integrate CircuitVerse with LMS' },
         { type: 'doc', id: 'chapter2/chapter2-ssointegration', label: 'Single Sign-On Configurations' },
-        { type: 'doc', id: 'chapter2/chapter2-bestpracticescv', label: 'Best Practices For Working With CircuitVerse' },
+        { type: 'doc', id: 'chapter2/chapter2-bestpracticescv', label: 'Best Practices for Working with CircuitVerse' },
       ],
     },
     {
@@ -66,7 +66,7 @@ const sidebars = {
       type: 'category',
       label: 'Chapter 6: Timing Diagrams and Delay',
       items: [
-        { type: 'doc', id: 'chapter6/chapter6-delayvsclock', label: 'Clock Time vs Delay' },
+        { type: 'doc', id: 'chapter6/chapter6-delayvsclock', label: 'Clock Time vs. Delay' },
         { type: 'doc', id: 'chapter6/chapter6-timingdiagram', label: 'Timing Diagram' },
       ],
     },


### PR DESCRIPTION
This PR improves the readability and consistency of sidebar labels by correcting minor capitalization and grammar issues in Chapter 2.

 Changes made:
- "CircuitVerse For Educators" → "CircuitVerse for Educators"
- "Best Practices For Working With CircuitVerse" → "Best Practices for Working with CircuitVerse"
- "Clock Time vs Delay" → "Clock Time vs. Delay"

These updates make the documentation titles more aligned with standard title formatting and improve overall clarity for readers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sidebar navigation labels for improved consistency and clarity across educator resources and technical documentation.

* **Style**
  * Applied capitalization and punctuation refinements to documentation titles for enhanced readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->