### PR TITLE
fix:  add white background to improve image visibility in dark mode 

### DIFF
--- a/src/css/darkTheme.css
+++ b/src/css/darkTheme.css
@@ -1,3 +1,8 @@
 .markdown-section td {
     background: #3F3F3F;
 }
+
+/* Fix image visibility in dark mode */
+[data-theme='dark'] .theme-doc-markdown img {
+    background-color: #ffffff;
+}


### PR DESCRIPTION
Closes #416 

#### Changes done:
- [x] Added CSS rule in `darkTheme.css` to apply white background to images in dark mode
- [x] Fix applies globally to all documentation pages
- [x] Light mode remains unaffected

#### Context:
PR #454 attempted to resolve this issue by replacing images with hardcoded white backgrounds. However, a CSS-based approach was requested as it's more maintainable and doesn't require modifying individual image files. Since there has been no response for over 3 weeks on that request, I've implemented the CSS fix directly.

**CSS Solution:**
```css
[data-theme='dark'] .theme-doc-markdown img {
    background-color: #ffffff;
}
```

#### Screenshots:

**Before (Dark Mode):**
<img width="1433" height="515" alt="Screenshot 2025-12-31 215311" src="https://github.com/user-attachments/assets/3796a3cc-4519-42ab-adc3-e031875d137c" />

**After (Dark Mode):**
<img width="1629" height="487" alt="Screenshot 2025-12-31 222952" src="https://github.com/user-attachments/assets/81413b9d-ef78-4854-9d10-5d12b78f3a1e" />


#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [ ] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image visibility in dark theme: images now render with an adjusted background so they display clearly and maintain proper contrast in dark mode, complementing existing dark-mode styling for other content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->