### PR TITLE
Improve readability of text above Figure 4.18 in Chapter 4 docs

### DIFF
--- a/docs/chapter4/8misc.md
+++ b/docs/chapter4/8misc.md
@@ -138,7 +138,10 @@ Table 4.20: CTR port input opcodes for different functionalities of ALU
 
 The **Adder** circuit element is a logical circuit of a full adder that performs an addition operation on binary numbers and produces a sum of the three inputs and a carry value (Cout). Figure 4.18 displays the different pins available for the **Adder **circuit element within CircuitVerse and Table 4.21 shares a brief description of the same.
 
-> Properties that can be customized in the **PROPERTIES** panel include: **Direction**
+:::note
+Properties that can be customized in the **PROPERTIES** panel include: **Direction**
+:::
+
 
 ![drawing](/img/img_chapter4/4.18.png)
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -34,8 +34,7 @@ const config = {
 				theme: {
 					customCss: [
 						require.resolve('./src/css/theme.css'),
-						require.resolve('./src/css/darkTheme.css'),
-						require.resolve('./src/css/custom.css'),
+						require.resolve('./src/css/darkTheme.css')
 					],
 				},
 			},

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,8 +1,0 @@
-/* === Custom global styles for CircuitVerse Docs === */
-@media (max-width: 650px) {
-  iframe {
-    width: 100%;
-    height: auto;
-    aspect-ratio: 4 / 3;
-  }
-}


### PR DESCRIPTION
Ref #485

This PR improves the readability of the text above Figure 4.18 by wrapping it
in a Docusaurus note, which provides better contrast in both light and dark
themes.

During investigation, I found that the low-contrast labels inside Figure 4.18
are part of the image asset itself, so adjusting them would require updating
the image rather than CSS or Markdown. This PR focuses on improving the
surrounding documentation text.

#### Changes done:
- [x] Improved readability of the text above Figure 4.18 using a Docusaurus note

#### Screenshots:
(Add before/after screenshot showing the text readability improvement)

#### Preview Link(s):
(Will be added after checks complete)

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has not already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [ ] Sample preview link added (will add after checks complete)
- [x] Tried squashing the commits into one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted a properties entry into a highlighted note for clearer presentation and improved readability.
* **Chores**
  * Cleaned up theme configuration to adjust which stylesheet is applied, simplifying the effective CSS load order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->