### PR TITLE
fix:  Incorrect project name in Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -19,7 +19,7 @@ Diversity and inclusion make the CircuitVerse community strong. We encourage par
 
 Harassment may include but not limited to the following:
 - Offensive, inappropriate, or unwanted comments related to gender, gender identity or expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, national origin, religion, or age, or other protected categories under applicable law.
-- Visual harassment eg. sexual imagery or use of sexual language at Docker community events
+- Visual harassment eg. sexual imagery or use of sexual language at CircuitVerse community events
 - Disrespect towards differences of opinion
 - Deliberate intimidation, stalking, harassing photography or recording
 - Sustained disruption of talks or other events


### PR DESCRIPTION
Fixes #491 

#### Changes done:
Fixed incorrect project name in Code of Conduct from "Docker community events" to "CircuitVerse community events" in the harassment examples section.

#### Screenshots:
N/A - This is a text-only change in a markdown file.

#### Preview Link(s):
[Add preview link after checks complete]

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [ ] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Code of Conduct to correct community event references in the unacceptable behavior section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->