### PR TITLE
Fix oversized SevenSegDisplay image in documentation

### DIFF
--- a/docs/chapter4/3output.md
+++ b/docs/chapter4/3output.md
@@ -155,7 +155,12 @@ You can verify the behavior of the **HexDisplay** circuit element in the live ci
 
 The **SevenSegDisplay** behaves similar to a **HexDisplay**, but it takes an 8-bit input rather than a 4-bit input––making it more customizable. It takes in eight inputs and displays an output, an integer from 1 to 9. As Figure 4.2 elucidates, the top four inputs correspond to the middle, top left, top, and top right segments from left to right respectively. The bottom four inputs correspond to the bottom left, bottom, bottom right, and decimal segments from left to right respectively.
 
-![](/img/img_chapter4/4.2.png)
+<img 
+  src="/img/img_chapter4/4.2.png" 
+  alt="Pin description of SevenSegDisplay"
+  style="max-height: 80vh; width: auto; display: block; margin: 0;"
+/>
+
 
 <div align="center">
   <em>Figure 4.2: Pin description of SevenSegDisplay</em>


### PR DESCRIPTION
Fixes #494 

#### Changes done:
- [x] Limited the height of the SevenSegDisplay image using HTML and CSS so it fits within the viewport.

#### Screenshots:
**Before (Image too tall, requires scrolling):**  
<img width="1900" height="904" alt="Screenshot 2026-01-09 115813" src="https://github.com/user-attachments/assets/5fc890a6-14da-4f44-813a-b8515daa7f1a" />

**After (Image fits in viewport):** 
<img width="1883" height="910" alt="Screenshot 2026-01-09 120111" src="https://github.com/user-attachments/assets/edd14ccd-c231-4fb5-a13d-a59846611df8" />

#### Preview Link(s):
(Add preview link from the checks tab after CI completes)

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (after checks complete)
- [x] Tried squashing the commits into one




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved visual rendering and accessibility of figures in documentation with enhanced formatting attributes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->