### PR TITLE
fix broken 'Edit this page' link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,7 +27,7 @@ const config = {
 			{
 				docs: {
 					sidebarPath: require.resolve('./sidebars.js'),
-					editUrl: 'https://github.com/CircuitVerse/CircuitVerseDocs/edit/master/docs/',
+					editUrl: 'https://github.com/CircuitVerse/CircuitVerseDocs/edit/master/',
 					routeBasePath: '/',
 				},
 				blog: false, // Disable blog


### PR DESCRIPTION
Fixes #500 

#### Changes done:
- [x] Fixed incorrect "Edit this page" GitHub URLs that contained `docs/docs`

#### Screenshots:
N/A (No UI changes)

#### Preview Link(s):
Will be added after checks complete

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [ ] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Edit this page" links in documentation to point to the repository root instead of the docs subfolder.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->