### PR TITLE
Remove outdated CircuitVerse Firefox extension link

### DIFF
--- a/docs/chapter2/2cvforeducators.md
+++ b/docs/chapter2/2cvforeducators.md
@@ -526,7 +526,8 @@ Follow the below steps to embed a CircuitVerse simulation within a web page:
 Since Google Slides does not support live circuit simulations, CircuitVerse live circuits can be embedded in Google Slides after installing the relevant browser extension.
 
 - CircuitVerse Chrome Extension: [Download link](https://chrome.google.com/webstore/detail/circuitverse/nmmehnggkgmdfbpfnebaimfjdbgmoaoo)
-- CircuitVerse Firefox Extension: Download link
+- CircuitVerse Firefox Extension: ⚠️ This extension is no longer maintained and has been removed.
+
 
 When the extension is successfully installed, it is displayed as an option in the menu bar. Refer to Figure 2.50.
 


### PR DESCRIPTION
Fixes #505 

### Summary
Removed the outdated CircuitVerse Firefox Extension link from the Docs – For Educators page.

### Changes Made
- [x] Removed broken Firefox extension download link
- [x] Added a note indicating the extension is no longer maintained
- [x] Verified Chrome extension link remains correct

### Result
- [x] Documentation now clearly shows that the Firefox extension is unavailable
- [x] No broken or misleading links remain for educators

### Challenges
- [x] Locating the exact line in the large `2cvforeducators.md` file
- [x] Ensuring formatting is consistent with existing Markdown
- [x] Preserving all other content and images in the file

### Updated Section
- CircuitVerse Chrome Extension: [Download link](https://chrome.google.com/webstore/detail/circuitverse/nmmehnggkgmdfbpfnebaimfjdbgmoaoo)
- CircuitVerse Firefox Extension: *No longer available* ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the educator documentation to reflect that the CircuitVerse Firefox extension is no longer maintained and has been removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->