### PR TITLE
docs: fix keyboard shortcut spelling in chapter docs

### DIFF
--- a/docs/chapter8/4shortcuts.mdx
+++ b/docs/chapter8/4shortcuts.mdx
@@ -16,7 +16,7 @@ description: "Shortcuts page in Chapter8 of CircuitVerse documentation."
 | Delete Object(s)                |          Delete          |
 | Select All                      |         Ctrl + a         |
 | De-select                       |           ESC            |
-| Deattach objects before placing |        Backspace         |
+| Detach objects before placing |        Backspace         |
 | Multi-object Select             | Ctrl + scroll using mouse |
 | Save Project Online             |         Ctrl + s         |
 | Save Project Offline            |     Ctrl + Shift + s     |

--- a/docs/chapter9/4shortcuts.md
+++ b/docs/chapter9/4shortcuts.md
@@ -10,8 +10,8 @@
 | Delete Object(s) | Delete |
 | Select All | Ctrl + a |
 | De-select | ESC |
-| Deattach objects before placing | Backspace |
-| Multi-object Select | Ctrl + scoll using mouse |
+| Detach objects before placing | Backspace |
+| Multi-object Select | Ctrl + scroll using mouse |
 | Save Project Online | Ctrl + s |
 | Save Project Offline | Ctrl + Shift + s |
 | Open Project | Ctrl + o |


### PR DESCRIPTION
Fixes #519

Updated keyboard shortcut labels in docs/chapter8/4shortcuts.mdx and docs/chapter9/4shortcuts.md.

Corrected Deattach to Detach in both files and scoll to scroll in chapter 9. This is a docs-only text correction.

How to verify: open both files and check the keyboard shortcut action labels in the table.