### PR TITLE
docs: fix typos in test circuits chapter text

### DIFF
--- a/docs/chapter7/3testcircuits.md
+++ b/docs/chapter7/3testcircuits.md
@@ -18,7 +18,7 @@ The test creator provides an intuitive UI to create tests.
  - Add another test to the group by clicking `+` icon below
  - Add another group by clicking `New Group`
 
-For sequential tests, clock is ticked between each Group. For combinational tests, Groups are just a logical seperation between different types of tests.
+For sequential tests, clock is ticked between each Group. For combinational tests, Groups are just a logical separation between different types of tests.
 
 Alternatively, you can also export the created test as CSV and edit it. You can import this CSV to attach by clicking `Import from CSV`
 

--- a/docs/chapter7/3testcircuits.mdx
+++ b/docs/chapter7/3testcircuits.mdx
@@ -27,9 +27,9 @@ The test creator provides an intuitive UI to create tests.
 - Add another test to the group by clicking `+` icon below
 - Add another group by clicking `New Group`
 
-For sequential tests, clock is ticked between each Group. For combinational tests, Groups are just a logical seperation between different types of tests.
+For sequential tests, clock is ticked between each Group. For combinational tests, Groups are just a logical separation between different types of tests.
 
-Alternatively, you can also export the created test as CSV and edit it. You can import this CSV to attch by clicking `Import from CSV`
+Alternatively, you can also export the created test as CSV and edit it. You can import this CSV to attach by clicking `Import from CSV`
 
 Finally,
 


### PR DESCRIPTION
Fixes #521

Updated typo text in docs/chapter7/3testcircuits.md and docs/chapter7/3testcircuits.mdx.

Corrected logical seperation to logical separation, and attch to attach in the MDX page.

How to verify: open both chapter 7 test circuits files and check the corrected words in the test creator section.