### PR TITLE
docs: fix information wording in lms integration guide

### DIFF
--- a/docs/chapter2/3lmsintegration.md
+++ b/docs/chapter2/3lmsintegration.md
@@ -121,7 +121,7 @@ You can configure CircuitVerse as an external app for Canvas. For more informati
 2. Select **Site Info** from the left sidebar.
 3. Click on **External Tools** tab.
 4. Click on **Install LTI 1.x Tool** link on the right of that page.
-5. Enter the following informations :
+5. Enter the following information :
 
 | Field in Sakai | Value or setting                                          |
 | -------------- | --------------------------------------------------------- |


### PR DESCRIPTION
Fixes #523

Updated one wording issue in docs/chapter2/3lmsintegration.md by changing following informations to following information.

This keeps the Sakai setup instruction grammatically correct.

How to verify: open docs/chapter2/3lmsintegration.md and check step 5 in the Sakai section.