### PR TITLE
docs: Fix MSB and LSB detector bit position descriptions

### DIFF
--- a/docs/chapter4/5muxandplex.md
+++ b/docs/chapter4/5muxandplex.md
@@ -254,7 +254,7 @@ Table 4.5: Truth table of a four-bit bit selector
 
 ## Most Significant Bit (MSB) Detector
 
-The **Most Significant Bit (MSB)** detector circuit element outputs the bit position of the most significant bit of the input. In other words, it outputs the bit position of the rightmost bit. An enable output is also provided to show if the MSB detector is active. The bit position of the MSB is also shown in decimal form within the body of the MSB detector.
+The **Most Significant Bit (MSB)** detector circuit element outputs the bit position of the most significant bit of the input. In other words, it outputs the bit position of the leftmost bit. An enable output is also provided to show if the MSB detector is active. The bit position of the MSB is also shown in decimal form within the body of the MSB detector.
 
 You can verify the behavior of the **Most Significant Bit (MSB)** detector circuit element with a four-bit input in the live circuit embedded below:
 
@@ -273,7 +273,7 @@ You can verify the behavior of the **Most Significant Bit (MSB)** detector circu
 
 ## Least Significant Bit (LSB) Detector
 
-The **Least Significant Bit (LSB)** detector circuit element outputs the bit position of the least significant bit of the input. In other words, it outputs the bit position of the leftmost bit. An enable output is also provided to show if the LSB detector is active. The bit position of the LSB is also shown in decimal form within the body of the LSB detector.
+The **Least Significant Bit (LSB)** detector circuit element outputs the bit position of the least significant bit of the input. In other words, it outputs the bit position of the rightmost bit. An enable output is also provided to show if the LSB detector is active. The bit position of the LSB is also shown in decimal form within the body of the LSB detector.
 
 You can verify the behavior of the **Least Significant Bit (LSB)** detector circuit element with a four-bit input in the live circuit embedded below:
 


### PR DESCRIPTION
Fixes #

#### Changes done:
- [x] Fixed MSB Detector description (changed "rightmost" to "leftmost")
- [x] Fixed LSB Detector description (changed "leftmost" to "rightmost")

#### Screenshots:
N/A - Text-only documentation fix

#### Preview Link(s):
Will be added after checks complete

<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [ ] Checked to see if a similar PR has already been opened 🤔️
- [ ] Reviewed the contributing guidelines 🔍️
- [ ] Sample preview link added (add a link from the checks tab after checks complete)
- [ ] Tried Squashing the commits into one

## Why This Matters
The previous descriptions were reversed and could confuse students learning digital logic. 

- MSB (Most Significant Bit) is the **leftmost** bit (highest place value)
- LSB (Least Significant Bit) is the **rightmost** bit (lowest place value)

The documentation previously had these reversed. As a student studying digital electronics, I noticed this error while reviewing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected textual descriptions for MSB and LSB detector documentation to accurately reflect bit positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->