### PR TITLE
docs: resize SevenSegDisplay figure

### DIFF
--- a/docs/chapter4/3output.md
+++ b/docs/chapter4/3output.md
@@ -156,7 +156,13 @@ You can verify the behavior of the **HexDisplay** circuit element in the live ci
 
 The **SevenSegDisplay** behaves similar to a **HexDisplay**, but it takes an 8-bit input rather than a 4-bit input––making it more customizable. It takes in eight inputs and displays an output, an integer from 1 to 9. As Figure 4.2 elucidates, the top four inputs correspond to the middle, top left, top, and top right segments from left to right respectively. The bottom four inputs correspond to the bottom left, bottom, bottom right, and decimal segments from left to right respectively.
 
-![](/img/img_chapter4/4.2.png)
+<div align="center">
+  <img
+    src="/img/img_chapter4/4.2.png"
+    alt="Pin description of SevenSegDisplay"
+    style={{ maxHeight: "70vh", width: "auto", maxWidth: "100%" }}
+  />
+</div>
 
 <div align="center">
   <em>Figure 4.2: Pin description of SevenSegDisplay</em>


### PR DESCRIPTION
## Summary
- replace the SevenSegDisplay figure markdown image with a centered responsive image
- cap the figure height at 70vh while preserving aspect ratio and max width

Fixes #494

## Test
- npm run build

## Notes
- Build passes with existing broken-anchor warnings unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved visual presentation of component diagrams with enhanced styling and centering
  * Added responsive layout improvements for documentation images
  * Updated formatting for better readability and display across different screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->